### PR TITLE
Add port number to node URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Once you have the faucet installed, you'll need to ensure you have a local
 Once the node is synced, execute the following command (from this directory) to
 deploy the faucet:
 ```
-lightning-faucet --lnd_ip=X.X.X.X
+lightning-faucet --lnd_ip=X.X.X.X --lnd_port=9735
 ```
 
 Where `X.X.X.X` is the public, reachable IP address for your active `lnd` node.

--- a/faucet.go
+++ b/faucet.go
@@ -385,7 +385,7 @@ func (l *lightningFaucet) fetchHomeState() (*homePageContext, error) {
 		return nil, err
 	}
 
-	nodeAddr := fmt.Sprintf("%v@%v", nodeInfo.IdentityPubkey, *lndIP)
+	nodeAddr := fmt.Sprintf("%v@%v:%v", nodeInfo.IdentityPubkey, *lndIP, *lndPort)
 	return &homePageContext{
 		NumCoins:    btcutil.Amount(walletBalance.Balance).ToBTC(),
 		NumChannels: nodeInfo.NumActiveChannels,

--- a/main.go
+++ b/main.go
@@ -36,8 +36,11 @@ var (
 	lndIP = flag.String("lnd_ip", "10.0.0.9", "the public IP address of "+
 		"the faucet's node")
 
+	// lndPort is the port listening for P2P connections.
+	lndPort = flag.String("lnd_port", "9735", "port to listen for P2P")
+
 	// port is the port that the http server should listen on.
-	port = flag.String("port", "8080", "port to list for http")
+	port = flag.String("port", "8080", "port to listen for HTTP")
 
 	// wipeChannels is a bool that indicates if all channels should be
 	// closed (either cooperatively or forcibly) on startup. If all


### PR DESCRIPTION
It took me a while to understand why the URI shown at https://faucet.lightning.community/ is invalid. Turns out the P2P port is required to use in the Eclair mobile app. It might not make a lot of sense to use a different port via `--lnd_port` but I guess it's better than hard-coding it.