### PR TITLE
Update btcd dependency to make glide install happy

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -39,7 +39,7 @@ imports:
   - lnrpc
   - macaroons
 - name: github.com/roasbeef/btcd
-  version: 34fdda7d41cc47d9456550fd1147a77db89f601a
+  version: a64d018fd91151b842522d64771610712565d30a
   subpackages:
   - btcec
   - chaincfg


### PR DESCRIPTION
`glide install` would throw this:

`Failed to set version on github.com/roasbeef/btcd to 34fdda7d41cc47d9456550fd1147a77db89f601a: Unable to update checked out version: exit status 128`