### PR TITLE
Updates the number of confirmations required for the channel to open.

### DIFF
--- a/faucet.go
+++ b/faucet.go
@@ -390,7 +390,7 @@ func (l *lightningFaucet) fetchHomeState() (*homePageContext, error) {
 		NumCoins:    btcutil.Amount(walletBalance.Balance).ToBTC(),
 		NumChannels: nodeInfo.NumActiveChannels,
 		NodeAddr:    nodeAddr,
-		NumConfs:    1,
+		NumConfs:    3,
 		Network:     l.network,
 	}, nil
 }


### PR DESCRIPTION
The default number of confirmations for funding flows has increased from 1 to 3

[Reference](https://github.com/lightningnetwork/lnd/commit/c5049125f8855b43d0c4b29cece2499a532439db)