### PR TITLE
fixing typo in 500 error

### DIFF
--- a/faucet.go
+++ b/faucet.go
@@ -566,7 +566,7 @@ func (l *lightningFaucet) openChannel(homeTemplate *template.Template,
 
 	openChanStream, err := l.lnd.OpenChannel(ctxb, openChanReq)
 	if err != nil {
-		http.Error(w, "unable to open chnnel", 500)
+		http.Error(w, "unable to open channel", 500)
 		return
 	}
 
@@ -574,7 +574,7 @@ func (l *lightningFaucet) openChannel(homeTemplate *template.Template,
 	// indicates that the channel has been broadcast to the network.
 	chanUpdate, err := openChanStream.Recv()
 	if err != nil {
-		http.Error(w, "unable to open chnnel", 500)
+		http.Error(w, "unable to open channel", 500)
 		return
 	}
 


### PR DESCRIPTION
Super small bug fix here. `channel` was spelled wrong. Getting a 500 right now on the deployed site as well, which is how I ran into this issue.