### PR TITLE
Fix Let's Encrypt issue

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 95a28cf8deff4dd1ef8df4da1517d47136f5291fc5281abdf7f9598bc41347ff
-updated: 2018-02-14T17:57:33.939805425-08:00
+hash: 29c6542310a11413d2aa90f038a082cd2f9bd96b62568d36b086fd89654cb090
+updated: 2018-03-31T22:44:54.456642565+09:00
 imports:
 - name: github.com/boltdb/bolt
   version: 2f1ce7a837dcb8da3ec595b1dac9d0632f0f99e8
@@ -16,6 +16,10 @@ imports:
   version: 346938d642f2ec3594ed81d874461961cd0faa76
   subpackages:
   - spew
+- name: github.com/golang/crypto
+  version: 3d37316aaa6bd9929127ac9a527abf408178ea7b
+  subpackages:
+  - acme/autocert
 - name: github.com/golang/protobuf
   version: ab9f9a6dab164b7d1246e0e688b0ab7b94d8553e
   subpackages:
@@ -72,7 +76,6 @@ imports:
   version: 9419663f5a44be8b34ca85f08abc5fe1be11f8a3
   subpackages:
   - acme
-  - acme/autocert
   - curve25519
   - nacl/box
   - nacl/secretbox
@@ -125,7 +128,7 @@ imports:
 - name: gopkg.in/errgo.v1
   version: 442357a80af5c6bf9b6d51ae791a39c3421004f3
 - name: gopkg.in/macaroon-bakery.v2
-  version: 04cf5ef151a211d929975161aea7c65f94c90446
+  version: 94012773d2874a067572bd16d7d11ae02968b47b
   subpackages:
   - bakery
   - bakery/checkers

--- a/glide.yaml
+++ b/glide.yaml
@@ -14,7 +14,8 @@ import:
   version: 7abdd30a878efb3673ce4dfe0070570a6c9444c8
   subpackages:
   - lnrpc
-- package: golang.org/x/crypto
+- package: github.com/golang/crypto
+  version: 3d37316aaa6bd9929127ac9a527abf408178ea7b
   subpackages:
   - acme/autocert
 - package: google.golang.org/grpc

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 	"reflect"
 	"time"
 
-	"golang.org/x/crypto/acme/autocert"
+	"github.com/golang/crypto/acme/autocert"
 
 	"github.com/gorilla/mux"
 )
@@ -157,14 +157,7 @@ func main() {
 
 	// As we'd like all requests to default to https, redirect all regular
 	// http requests to the https version of the faucet.
-	go http.ListenAndServe(":80", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		targetURL := "https://" + r.Host + r.URL.String()
-		if len(r.URL.RawQuery) > 0 {
-			targetURL += "?" + r.URL.RawQuery
-		}
-
-		http.Redirect(w, r, targetURL, http.StatusPermanentRedirect)
-	}))
+	go http.ListenAndServe(":80", m.HTTPHandler(nil))
 
 	// Finally, create the http server, passing in our TLS configuration.
 	httpServer := &http.Server{


### PR DESCRIPTION
Using github.com/golang/crypto at their most recent version includes http support for the LE challenge.

https://github.com/golang/crypto/commit/13931e22f9e72ea58bb73048bc752b48c6d4d4ac

13 days ago they added this as a workaround to the issues where LE has removed the other challenge methods due to a vuln.

For now HTTP is the only method available to go's acmecert package.

Some of the glide dependencies in glide.lock got borked when I ran glide update... so I will leave the branch open to edits from maintainers.

This branch currently builds for us and works fine.

Thanks.