### PR TITLE
Change the default channel amount and fix misspellings

### DIFF
--- a/faucet.go
+++ b/faucet.go
@@ -568,7 +568,7 @@ func (l *lightningFaucet) openChannel(homeTemplate *template.Template,
 
 	openChanStream, err := l.lnd.OpenChannel(ctxb, openChanReq)
 	if err != nil {
-		http.Error(w, "unable to open chnnel", 500)
+		http.Error(w, "unable to open channel", 500)
 		return
 	}
 
@@ -576,7 +576,7 @@ func (l *lightningFaucet) openChannel(homeTemplate *template.Template,
 	// indicates that the channel has been broadcast to the network.
 	chanUpdate, err := openChanStream.Recv()
 	if err != nil {
-		http.Error(w, "unable to open chnnel", 500)
+		http.Error(w, "unable to open channel", 500)
 		return
 	}
 

--- a/static/index.html
+++ b/static/index.html
@@ -49,7 +49,7 @@
 
                   <div class="row">
                       <div class="input-field col s12">
-                          <input placeholder="100000" 
+                          <input placeholder="1000000" 
                              {{if eq .SubmissionError 3 4 5}} 
                                 class="invalid" 
                              {{end}}


### PR DESCRIPTION
- The default channel amount of 100,000 satoshis is too low and doesn't work on testnet, change it to 1,000,000
- Fix misspellings in error messages (`chnnel` instead of `channel` in `faucet.go`)